### PR TITLE
DEV-516: Copy to a statically-named file

### DIFF
--- a/scripts/retrieve_deprecated_oclcs.sh
+++ b/scripts/retrieve_deprecated_oclcs.sh
@@ -2,8 +2,7 @@ export PATH="$HOME/.rbenv/bin:$PATH"
 export PATH="$HOME/bin:$PATH"
 
 # copy to /htdata
-D=$(date +\%Y-\%m-\%d)
-cp data/rejected_oclc_nums.txt /htdata/govdocs/feddocs_oclc_filter/oclcs_removed_from_registry_$D.txt
+cp data/rejected_oclc_nums.txt /htdata/govdocs/feddocs_oclc_filter/oclcs_removed_from_registry.txt
 
 # This is now done manually, by adding to data/rejected_oclc_nums.txt
 #git commit data/oclcs_removed_from_registry.txt -m 'OCLC update' --author="Josh Steverman <jstever@umich.edu>"


### PR DESCRIPTION
- Avoids duplication of lots of data
- Avoids race condition when this script hasn't run before the thing that needs it
- If we need history of what items were rejected on a given day, we can look at the commit history for data/rejected_oclc_nums.txt